### PR TITLE
update image URL in k8s deploy file

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: expense-tracker
-        image: iamnwi/expense-tracker:latest
+        image: us.icr.io/nyu-cc/expense-tracker:latest
         ports:
         - containerPort: 3000
           name: expense-tracker


### PR DESCRIPTION
Update target image URL from docker hub to IBM image hub. It because the IBM pipeline build and push the image to the IBM image hub. Change it to keep sync.